### PR TITLE
Update beam-mysql to lts-13.1

### DIFF
--- a/Database/Beam/MySQL/Connection.hs
+++ b/Database/Beam/MySQL/Connection.hs
@@ -27,6 +27,8 @@ import qualified Database.MySQL.Base.Types as MySQL
 
 import           Control.Exception
 import           Control.Monad.Except
+import           Control.Monad.Fail (MonadFail)
+import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Free.Church
 import           Control.Monad.Reader
 
@@ -56,6 +58,10 @@ instance BeamBackend MySQL where
 
 newtype MySQLM a = MySQLM (ReaderT (String -> IO (), Connection) IO a)
     deriving (Monad, MonadIO, Applicative, Functor)
+
+instance MonadFail MySQLM where
+    fail e = fail $ "Internal Error with: " <> show e
+
 data NotEnoughColumns
     = NotEnoughColumns
     { _errColCount :: Int

--- a/Database/Beam/MySQL/Syntax.hs
+++ b/Database/Beam/MySQL/Syntax.hs
@@ -145,10 +145,11 @@ instance IsSql92InsertValuesSyntax MysqlInsertValuesSyntax where
 instance IsSql92DeleteSyntax MysqlDeleteSyntax where
     type Sql92DeleteExpressionSyntax MysqlDeleteSyntax = MysqlExpressionSyntax
 
-    deleteStmt tbl where_ =
+    deleteStmt tbl _ where_ =
       MysqlDeleteSyntax $
       emit "DELETE FROM " <> mysqlIdentifier tbl <>
       maybe mempty (\where' -> emit " WHERE " <> fromMysqlExpression where') where_
+    deleteSupportsAlias _ = False
 
 instance IsSql92SelectSyntax MysqlSelectSyntax where
     type Sql92SelectSelectTableSyntax MysqlSelectSyntax = MysqlSelectTableSyntax

--- a/beam-mysql.cabal
+++ b/beam-mysql.cabal
@@ -26,13 +26,13 @@ library
                       bytestring           >=0.10 && <0.11,
 
                       attoparsec,
-                      aeson                >=0.11 && <1.4,
+                      aeson                >=0.11 && <1.5,
                       hashable             >=1.1  && <1.3,
                       time                 >=1.6  && <1.10,
                       mtl                  >=2.1  && <2.3,
                       case-insensitive     >=1.2  && <1.3,
                       scientific           >=0.3  && <0.4,
-                      free                 >=4.12 && <5.1,
+                      free                 >=4.12 && <5.2,
                       network-uri
   default-language:   Haskell2010
   default-extensions: ScopedTypeVariables, OverloadedStrings, MultiParamTypeClasses, RankNTypes, FlexibleInstances,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 #resolver: lts-9.0
 #resolver: lts-10.3
-resolver: lts-11.2
+resolver: lts-13.1
 extra-deps:
   - ../beam/beam-core
 


### PR DESCRIPTION
Bumps `beam-mysql` to LTS 13.1 for GHC 8.6.3.