### PR TITLE
Added ByteString instance for HasSqlValueSyntax MySQLValueSyntax

### DIFF
--- a/Database/Beam/MySQL/Syntax.hs
+++ b/Database/Beam/MySQL/Syntax.hs
@@ -520,6 +520,13 @@ instance HasSqlValueSyntax MysqlValueSyntax TL.Text where
 instance HasSqlValueSyntax MysqlValueSyntax [Char] where
     sqlValueSyntax = sqlValueSyntax . T.pack
 
+instance HasSqlValueSyntax MysqlValueSyntax ByteString where
+    sqlValueSyntax t =
+        MysqlValueSyntax $ MysqlSyntax
+        (\next doEscape before conn ->
+             do escaped <- doEscape t
+                next doEscape (before <> "'" <> byteString escaped <> "'") conn)
+
 instance HasSqlValueSyntax MysqlValueSyntax Scientific where
     sqlValueSyntax = MysqlValueSyntax . emit . scientificBuilder
 


### PR DESCRIPTION
I added the missing instance which now lets you use MySQL Text and Blob types. There is no conversion being done. So if one actually wants to store UTF-8 you need to make sure the ByteString is encoded with UTF-8.